### PR TITLE
Added Entity values to island level calculation

### DIFF
--- a/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandLevel.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandLevel.java
@@ -33,6 +33,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.type.Leaves;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import java.util.UUID;
@@ -128,7 +129,7 @@ public class IslandLevel extends PlayerSubCommand {
                                 }
 
                                 int roundlevel = (int) Math.floor(level);
-                                plugin.getDb().getWriter().updateIslandLevel(playerInfo.getIslandId(), roundlevel, c.blocks, player.getUniqueId());
+                                plugin.getDb().getWriter().updateIslandLevel(playerInfo.getIslandId(), roundlevel, c.blocks, c.entities, player.getUniqueId());
                                 ConfigShorts.custommessagefromString("NewIslandLevel", player, String.valueOf(roundlevel));
                                 IslandCacheHandler.islandlevels.put(playerInfo.getIslandName(), roundlevel);
                             });
@@ -200,6 +201,7 @@ public class IslandLevel extends PlayerSubCommand {
     public static class IslandCounter {
         public double value;
         public int blocks;
+        public int entities;
         private int toCount = 0;
         private final Consumer<IslandCounter> onDone;
 
@@ -234,6 +236,15 @@ public class IslandLevel extends PlayerSubCommand {
                             value = value + DefaultFiles.blockvalues.getOrDefault(block.getType(), 0D);
                         }
                     }
+                }
+
+                for (Entity entity : chunk.getEntities()) {
+                    if(!entity.isPersistent() || entity.isDead() || entity instanceof Player) {
+                        continue;
+                    }
+
+                    entities = entities + 1;
+                    value = value + DefaultFiles.entityvalues.getOrDefault(entity.getType(), 0D);
                 }
             }
             if (--toCount == 0) {

--- a/src/main/java/com.github.Viduality.VSkyblock/DefaultFiles.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/DefaultFiles.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.EnumMap;
 import java.util.Map;
+import org.bukkit.entity.EntityType;
 
 public class DefaultFiles {
 
@@ -17,6 +18,7 @@ public class DefaultFiles {
     private static VSkyblock plugin = VSkyblock.getInstance();
 
     public static Map<Material, Double> blockvalues = new EnumMap<>(Material.class);
+    public static Map<EntityType, Double> entityvalues = new EnumMap<>(EntityType.class);
 
     /**
      * Check default Files
@@ -25,8 +27,10 @@ public class DefaultFiles {
     public static void init() {
         saveDefaultConfig("Worlds.yml");
         saveDefaultConfig("BlockValues.yml");
+        saveDefaultConfig("EntityValues.yml");
 
         reloadBlockValues();
+        reloadEntityValues();
 
 
     }
@@ -99,6 +103,39 @@ public class DefaultFiles {
 
         } catch (Exception e) {
             plugin.getLogger().info("Problem reading block values file.");
+            e.printStackTrace();
+        }
+    }
+
+    public static void reloadEntityValues() {
+        File configFile = new File(plugin.getDataFolder(), "EntityValues.yml");
+        if (!configFile.exists()) {
+            plugin.getLogger().info("EntityValues.yml does not exist!");
+            return;
+        }
+        if (!entityvalues.isEmpty()) {
+            entityvalues.clear();
+        }
+        FileConfiguration entityValuesConfig = new YamlConfiguration();
+        try {
+            entityValuesConfig.load(configFile);
+
+            for (String configString : entityValuesConfig.getKeys(false)) {
+                String entity = configString.toUpperCase();
+                if (EntityType.valueOf(entity) != null) {
+                    double value = entityValuesConfig.getDouble(configString, -1);
+                    if (value > -1) {
+                        entityvalues.put(EntityType.valueOf(entity), value);
+                    } else {
+                        plugin.getLogger().info("Entity: " + entity + " has an invalid block value (" + entityValuesConfig.get(configString) + ")");
+                    }
+                } else {
+                    plugin.getLogger().info("Entity string " + configString + " is not a valid entity!");
+                }
+            }
+
+        } catch (Exception e) {
+            plugin.getLogger().info("Problem reading entity values file.");
             e.printStackTrace();
         }
     }

--- a/src/main/java/com.github.Viduality.VSkyblock/SQLConnector.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/SQLConnector.java
@@ -157,6 +157,7 @@ public class SQLConnector {
                             + "visitneedsrequest BOOLEAN NOT NULL DEFAULT FALSE,"
                             + "cobblestonelevel BIGINT DEFAULT 0,"
                             + "totalblocks BIGINT DEFAULT 140,"
+                            + "totalentities BIGINT DEFAULT 0,"
                             + "PRIMARY KEY (islandid))");
             connection.createStatement().execute(
                     "CREATE TABLE IF NOT EXISTS VSkyblock_IslandLocations("
@@ -194,6 +195,7 @@ public class SQLConnector {
             connection.createStatement().execute(
                     "ALTER TABLE VSkyblock_Island ADD COLUMN IF NOT EXISTS("
                     + "visitneedsrequest BOOLEAN NOT NULL DEFAULT FALSE,"
+                    + "totalentities BIGINT DEFAULT 0,"
                     + "totalblocks BIGINT DEFAULT 140);"
             );
             connection.createStatement().execute(

--- a/src/main/java/com.github.Viduality.VSkyblock/Utilitys/DatabaseWriter.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/Utilitys/DatabaseWriter.java
@@ -322,14 +322,15 @@ public class DatabaseWriter {
      * @param islandid
      * @param level
      */
-    public void updateIslandLevel(int islandid, Integer level, Integer totalblocks, UUID uuid) {
+    public void updateIslandLevel(int islandid, Integer level, Integer totalblocks, Integer totalentities, UUID uuid) {
         connector.getReader().getIslandMembers(islandid, result -> plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
             try (Connection connection = connector.getConnection()) {
                 PreparedStatement updateChallengeCount;
-                updateChallengeCount = connection.prepareStatement("UPDATE VSkyblock_Island SET islandlevel = ?, totalblocks = ? WHERE islandid = ?");
+                updateChallengeCount = connection.prepareStatement("UPDATE VSkyblock_Island SET islandlevel = ?, totalblocks = ?, totalentities = ?, WHERE islandid = ?");
                 updateChallengeCount.setInt(1, level);
                 updateChallengeCount.setInt(2, totalblocks);
-                updateChallengeCount.setInt(3, islandid);
+                updateChallengeCount.setInt(3, totalentities);
+                updateChallengeCount.setInt(4, islandid);
                 updateChallengeCount.executeUpdate();
                 updateChallengeCount.close();
 

--- a/src/main/resources/EntityValues.yml
+++ b/src/main/resources/EntityValues.yml
@@ -1,0 +1,2 @@
+armor_stand: 1
+arrow: 0


### PR DESCRIPTION
Closes issue https://github.com/Minebench/VSkyblock/issues/11. 

Might benefit from the following improvements:
- Rewriting the default config file logic to load a generic enum, avoiding duplicate code.
- More entity types in the default config


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#11: Make Entities count in island level](https://oss.issuehunt.io/repos/253941367/issues/11)
---
</details>
<!-- /Issuehunt content-->