### PR TITLE
Implemented feature from Issue #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 target
 dependency-reduced-pom.xml
 *.iml
+.vscode

--- a/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandCommand.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandCommand.java
@@ -56,6 +56,7 @@ public class IslandCommand extends PlayerSubCommand {
         registerSubCommand(new IslandSetOwner(plugin));
         registerSubCommand(new IslandVisit(plugin));
         registerSubCommand(new IslandConfirm(plugin));
+        registerSubCommand(new IslandInfo(plugin));
     }
 
     @Override

--- a/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandInfo.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandInfo.java
@@ -1,0 +1,152 @@
+package com.github.Viduality.VSkyblock.Commands;
+
+import com.github.Viduality.VSkyblock.VSkyblock;
+import com.github.Viduality.VSkyblock.Utilitys.ConfigShorts;
+import com.github.Viduality.VSkyblock.Utilitys.PlayerInfo;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.ChatColor;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.Duration;
+import java.time.Period;
+
+public class IslandInfo extends PlayerSubCommand {
+
+    public IslandInfo(VSkyblock plugin) {
+        super(plugin, "info");
+    }
+
+    @Override
+    public void execute(CommandSender sender, PlayerInfo playerInfo, String[] args) {
+        if (playerInfo.getIslandId() == 0) {
+            ConfigShorts.messagefromString("NoIsland", playerInfo.getPlayer());
+            return;
+        }
+
+        ConfigShorts.messagefromString("IslandInfoLoading", sender);
+
+        plugin.getDb().getReader().getIslandsChallengePoints(playerInfo.getIslandId(), (challengePoints) -> {
+            plugin.getDb().getReader().getIslandMembersTotal(playerInfo.getIslandId(), (totalMembers) -> {
+
+                StringBuilder sb = new StringBuilder();
+
+                sb.append(ConfigShorts.getMessageConfig().getString("IslandInfoLabelAge"));
+                Timestamp dateCreated = playerInfo.getIslandCreated();
+                LocalDateTime createdDateTime = dateCreated.toLocalDateTime();
+                LocalDateTime currentDateTime = LocalDateTime.now();
+
+                Period period = Period.between(createdDateTime.toLocalDate(), currentDateTime.toLocalDate());
+                Duration duration = Duration.between(createdDateTime, currentDateTime);
+
+
+                if (period.getYears() > 0) {
+                    sb.append(period.getYears())
+                            .append(" years, ")
+                            .append(period.getMonths())
+                            .append(" months, ")
+                            .append(period.getDays())
+                            .append(" days old");
+                } else if (period.getMonths() > 0) {
+                    sb.append(" months, ")
+                            .append(period.getDays())
+                            .append(" days old");
+                } else if (period.getDays() > 0) {
+                    sb.append(period.getDays())
+                            .append(" days old");
+                } else if (duration.toHours() > 0) {
+                    sb.append(duration.toHours())
+                            .append(" hours old");
+                } else if (duration.toMinutes() > 0) {
+                    sb.append(duration.toMinutes())
+                            .append(" minutes old");
+                } else {
+                    sb.append(duration.toSeconds())
+                            .append(" seconds old");
+                }
+                sb.append("\n");
+
+                World world = plugin.getServer().getWorld(playerInfo.getIslandName());
+
+                double worldsize = world.getWorldBorder().getSize();
+
+                sb.append(ConfigShorts.getMessageConfig().getString("IslandInfoLabelSize"));
+                sb.append(worldsize);
+                sb.append(" ")
+                        .append(ConfigShorts.getMessageConfig().getString("IslandInfoLabelSizeUnits"));
+                sb.append("\n");
+
+                sb.append(ConfigShorts.getMessageConfig().getString("IslandInfoLabelDifficulty"));
+                sb.append(world.getDifficulty());
+                sb.append("\n");
+
+                sb.append(ConfigShorts.getMessageConfig().getString("IslandInfoLabelTotalMembers"));
+                sb.append(totalMembers);
+                sb.append("\n");
+
+                sb.append(ConfigShorts.getMessageConfig().getString("IslandInfoLabelXBorder"));
+                sb.append(worldsize / -2).append(" to ").append(worldsize / 2);
+                sb.append("\n");
+
+                sb.append(ConfigShorts.getMessageConfig().getString("IslandInfoLabelZBorder"));
+                sb.append(worldsize / -2).append(" to ").append(worldsize / 2);
+                sb.append("\n");
+
+                sb.append(ConfigShorts.getMessageConfig().getString("IslandInfoLabelLevel"));
+                sb.append(playerInfo.getIslandLevel());
+                sb.append("\n");
+
+                sb.append(ConfigShorts.getMessageConfig().getString("IslandInfoLabelProgress"));
+
+                int valueperlevel;
+                if (isInt(ConfigShorts.getDefConfig().getString("IslandValue"))) {
+                    valueperlevel = ConfigShorts.getDefConfig().getInt("IslandValue");
+                } else {
+                    valueperlevel = 300;
+                }
+
+                double value = 0;
+                if (isInt(ConfigShorts.getDefConfig().getString("IslandValueonStart"))) {
+                    value = ConfigShorts.getDefConfig().getInt("IslandValueonStart");
+                } else {
+                    value = 150;
+                }
+                value = value + challengePoints;
+
+                sb.append(value - (getValueIncrease() * playerInfo.getIslandLevel()))
+                        .append("/")
+                        .append((getValueIncrease() * playerInfo.getIslandLevel()) + valueperlevel);
+                sb.append("\n");
+
+                sb.append(ConfigShorts.getMessageConfig().getString("IslandInfoLabelChallenges"));
+                sb.append(playerInfo.getChallengesCompleted());
+                sb.append("\n");
+
+                sender.sendMessage(ChatColor.translateAlternateColorCodes('&', sb.toString()));
+            });
+        });
+    }
+
+    private static boolean isInt(String s) {
+        try {
+            Integer.parseInt(s);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+        return true;
+    }
+
+    private static int getValueIncrease() {
+        String s = ConfigShorts.getDefConfig().getString("IslandValueIncreasePerLevel");
+        if (s != null) {
+            if (isInt(s)) {
+                return Integer.parseInt(s);
+            } else {
+                return 20;
+            }
+        } else {
+            return 20;
+        }
+    }
+}

--- a/src/main/java/com.github.Viduality.VSkyblock/SQLConnector.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/SQLConnector.java
@@ -158,6 +158,7 @@ public class SQLConnector {
                             + "cobblestonelevel BIGINT DEFAULT 0,"
                             + "totalblocks BIGINT DEFAULT 140,"
                             + "totalentities BIGINT DEFAULT 0,"
+                            + "time_created TIMESTAMP NOT NULL,"
                             + "PRIMARY KEY (islandid))");
             connection.createStatement().execute(
                     "CREATE TABLE IF NOT EXISTS VSkyblock_IslandLocations("

--- a/src/main/java/com.github.Viduality.VSkyblock/Utilitys/DatabaseWriter.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/Utilitys/DatabaseWriter.java
@@ -26,10 +26,8 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
+import java.util.Date;
 import java.util.UUID;
 
 public class DatabaseWriter {
@@ -76,9 +74,10 @@ public class DatabaseWriter {
         plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
             try (Connection connection = connector.getConnection()) {
                 PreparedStatement preparedStatement;
-                preparedStatement = connection.prepareStatement("INSERT INTO VSkyblock_Island(island, difficulty) VALUES(?, ?)");
+                preparedStatement = connection.prepareStatement("INSERT INTO VSkyblock_Island(island, difficulty, time_created) VALUES(?, ?, ?)");
                 preparedStatement.setString(1, island);
                 preparedStatement.setString(2, difficutly);
+                preparedStatement.setTimestamp(3, new Timestamp(new Date().getTime()));
                 preparedStatement.executeUpdate();
                 preparedStatement.close();
             } catch (SQLException e) {

--- a/src/main/java/com.github.Viduality.VSkyblock/Utilitys/PlayerInfo.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/Utilitys/PlayerInfo.java
@@ -3,6 +3,7 @@ package com.github.Viduality.VSkyblock.Utilitys;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+import java.sql.Timestamp;
 import java.util.UUID;
 
 public class PlayerInfo {
@@ -14,6 +15,24 @@ public class PlayerInfo {
     private String islandName = null;
     private int islandLevel = 0;
     private int deathCount = 0;
+    private Timestamp islandCreated = null;
+    private int challengesCompleted = 0;
+
+    public int getChallengesCompleted() {
+        return challengesCompleted;
+    }
+
+    public void setChallengesCompleted(int challengesCompleted) {
+        this.challengesCompleted = challengesCompleted;
+    }
+
+    public Timestamp getIslandCreated() {
+        return islandCreated;
+    }
+
+    public void setIslandCreated(Timestamp islandCreated) {
+        this.islandCreated = islandCreated;
+    }
 
 
     /**

--- a/src/main/resources/eng.yml
+++ b/src/main/resources/eng.yml
@@ -150,3 +150,16 @@ WorldListHeader: '§bVSkyblock worlds:'
 WorldLoaded: §bWorld loaded successfully!
 WorldNotFound: §cWorld §6%replacement% §cnot found!
 WorldUnloaded: §bWorld unloaded successfully!
+
+IslandInfoLoading: §aLoading your island's information...
+#Supports '&' Chat colors
+IslandInfoLabelAge: '&e&lIsland Age&7: &a'
+IslandInfoLabelSize: '&e&lIsland Size&7: &a'
+IslandInfoLabelSizeUnits: '&ablocks'
+IslandInfoLabelDifficulty: '&e&lIsland Difficulty&7: &a'
+IslandInfoLabelTotalMembers: '&e&lIsland Total Members&7: &a'
+IslandInfoLabelZBorder: '&e&lIsland Z Border&7: &a'
+IslandInfoLabelXBorder: '&e&lIsland X Border&7: &a'
+IslandInfoLabelLevel: '&e&lIsland Level&7: &a'
+IslandInfoLabelProgress: '&e&lLevel Progress&7: &a'
+IslandInfoLabelChallenges: '&e&lChallenges Completed&7: &a'


### PR DESCRIPTION
Added the following for the eng.yml

Line 154
```yaml
IslandInfoLoading: §aLoading your island's information...
#Supports '&' Chat colors
IslandInfoLabelAge: '&e&lIsland Age&7: &a'
IslandInfoLabelSize: '&e&lIsland Size&7: &a'
IslandInfoLabelSizeUnits: '&ablocks'
IslandInfoLabelDifficulty: '&e&lIsland Difficulty&7: &a'
IslandInfoLabelTotalMembers: '&e&lIsland Total Members&7: &a'
IslandInfoLabelZBorder: '&e&lIsland Z Border&7: &a'
IslandInfoLabelXBorder: '&e&lIsland X Border&7: &a'
IslandInfoLabelLevel: '&e&lIsland Level&7: &a'
IslandInfoLabelProgress: '&e&lLevel Progress&7: &a'
IslandInfoLabelChallenges: '&e&lChallenges Completed&7: &a'
```

Sample usage: 
![image](https://github.com/Minebench/VSkyblock/assets/68337605/6653a856-5fb5-4022-bdf8-b8de04b8f58a)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#9: Island information display](https://oss.issuehunt.io/repos/253941367/issues/9)
---
</details>
<!-- /Issuehunt content-->