### PR TITLE
Add /island info command with island summary output

### DIFF
--- a/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandCommand.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandCommand.java
@@ -47,6 +47,7 @@ public class IslandCommand extends PlayerSubCommand {
         registerSubCommand(new IslandMembers(plugin));
         registerSubCommand(new IslandLevel(plugin));
         registerSubCommand(new IslandTop(plugin));
+        registerSubCommand(new IslandInfo(plugin));
         registerSubCommand(new IslandOptions(plugin));
         registerSubCommand(new IslandSetNetherhome(plugin));
         registerSubCommand(new IslandNether(plugin));

--- a/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandHelp.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandHelp.java
@@ -65,6 +65,7 @@ public class IslandHelp extends SubCommand {
                 ChatColor.GOLD + ChatColor.BOLD + "/island leave" + "\n" + ChatColor.RESET + " - " + leave + "\n" +
                 ChatColor.GOLD + ChatColor.BOLD + "/island leave confirm" + "\n" + ChatColor.RESET + " - " + leaveconfirm + "\n" +
                 ChatColor.GOLD + ChatColor.BOLD + "/island level" + "\n" + ChatColor.RESET + " - " + level + "\n" +
+                ChatColor.GOLD + ChatColor.BOLD + "/island info" + "\n" + ChatColor.RESET + " - Shows island age, range, level and challenge progress\n" +
                 ChatColor.GOLD + ChatColor.BOLD + "/island members" + "\n" + ChatColor.RESET + " - " + members + "\n" +
                 ChatColor.GOLD + ChatColor.BOLD + "/island options" + "\n" + ChatColor.RESET + " - " + options + "\n" +
                 ChatColor.GOLD + ChatColor.BOLD + "/island top" + "\n" + ChatColor.RESET + " - " + top + "\n" +

--- a/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandInfo.java
+++ b/src/main/java/com.github.Viduality.VSkyblock/Commands/IslandInfo.java
@@ -1,0 +1,79 @@
+package com.github.Viduality.VSkyblock.Commands;
+
+import com.github.Viduality.VSkyblock.Challenges.ChallengesManager;
+import com.github.Viduality.VSkyblock.Utilitys.ChallengesCache;
+import com.github.Viduality.VSkyblock.Utilitys.ConfigShorts;
+import com.github.Viduality.VSkyblock.Utilitys.IslandCacheHandler;
+import com.github.Viduality.VSkyblock.Utilitys.PlayerInfo;
+import com.github.Viduality.VSkyblock.VSkyblock;
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.time.Duration;
+
+public class IslandInfo extends PlayerSubCommand {
+
+    public IslandInfo(VSkyblock plugin) {
+        super(plugin, "info");
+    }
+
+    @Override
+    public void execute(CommandSender sender, PlayerInfo playerInfo, String[] args) {
+        if (playerInfo.getIslandId() == 0) {
+            ConfigShorts.messagefromString("NoIsland", playerInfo.getPlayer());
+            return;
+        }
+
+        Player player = playerInfo.getPlayer();
+        if (player == null) {
+            return;
+        }
+
+        plugin.getDb().getReader().getIslandChallenges(playerInfo.getIslandId(), (ChallengesCache cache) -> {
+            plugin.getDb().getReader().getIslandLevelFromUuid(player.getUniqueId(), islandLevel -> {
+                plugin.getDb().getReader().getIslandMembers(playerInfo.getIslandId(), members -> {
+                    int completedChallenges = (int) cache.getAllChallengeCounts().values().stream().filter(v -> v != null && v > 0).count();
+                    int totalChallenges = ChallengesManager.challenges.size();
+
+                    String islandName = playerInfo.getIslandName() != null ? playerInfo.getIslandName() : "unknown";
+                    World world = plugin.getServer().getWorld(islandName);
+
+                    String ageText = "unknown";
+                    String buildRangeText = "unknown";
+                    if (world != null) {
+                        File worldFolder = world.getWorldFolder();
+                        if (worldFolder != null && worldFolder.exists()) {
+                            long ageMillis = Math.max(0, System.currentTimeMillis() - worldFolder.lastModified());
+                            long days = Duration.ofMillis(ageMillis).toDays();
+                            long hours = Duration.ofMillis(ageMillis).toHours() % 24;
+                            ageText = days + "d " + hours + "h";
+                        }
+
+                        double radius = world.getWorldBorder().getSize() / 2.0;
+                        buildRangeText = "±" + String.format("%.0f", radius) + " blocks (X/Z)";
+                    } else if (ConfigShorts.getDefConfig().contains("WorldSize")) {
+                        double radius = ConfigShorts.getDefConfig().getDouble("WorldSize", 500D) / 2.0;
+                        buildRangeText = "±" + String.format("%.0f", radius) + " blocks (X/Z)";
+                    }
+
+                    sender.sendMessage(ChatColor.AQUA + "--- Island Info ---");
+                    sender.sendMessage(ChatColor.GOLD + "Island: " + ChatColor.RESET + islandName);
+                    sender.sendMessage(ChatColor.GOLD + "Age: " + ChatColor.RESET + ageText);
+                    sender.sendMessage(ChatColor.GOLD + "Build range: " + ChatColor.RESET + buildRangeText);
+                    sender.sendMessage(ChatColor.GOLD + "Level: " + ChatColor.RESET + islandLevel);
+                    sender.sendMessage(ChatColor.GOLD + "Members: " + ChatColor.RESET + members.size());
+                    sender.sendMessage(ChatColor.GOLD + "Challenge progress: " + ChatColor.RESET
+                            + completedChallenges + "/" + totalChallenges);
+
+                    Integer cachedLevel = IslandCacheHandler.islandlevels.get(islandName);
+                    if (cachedLevel == null || !cachedLevel.equals(islandLevel)) {
+                        IslandCacheHandler.islandlevels.put(islandName, islandLevel);
+                    }
+                });
+            });
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add new `/island info` subcommand
- show island age, build range (X/Z), island level, member count, and challenge progress
- register command in `IslandCommand` and include in help text

## Why
Issue #9 requests `/is info` style summary information for island status. This introduces an MVP command with the most useful core fields in one response.

## Notes
- age is derived from world folder last-modified time
- build range uses world border size, with config fallback

Closes #9